### PR TITLE
Add microphone usage description

### DIFF
--- a/ALVRClient.xcodeproj/project.pbxproj
+++ b/ALVRClient.xcodeproj/project.pbxproj
@@ -327,6 +327,8 @@
 				EXCLUDED_ARCHS = x86_64;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "$(TARGET_NAME)/Info.plist";
+				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "For connecting to ALVR server on local network.";
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Used for in game voice chat";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -362,6 +364,8 @@
 				EXCLUDED_ARCHS = x86_64;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "$(TARGET_NAME)/Info.plist";
+				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "For connecting to ALVR server on local network.";
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Used for in game voice chat";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/ALVRClient/Info.plist
+++ b/ALVRClient/Info.plist
@@ -11,7 +11,5 @@
 		<key>UISceneConfigurations</key>
 		<dict/>
 	</dict>
-	<key>NSLocalNetworkUsageDescription</key>
-	<string>For connecting to ALVR server on local network.</string>
 </dict>
 </plist>


### PR DESCRIPTION
Stops a crash due to lack of microphone permissions.